### PR TITLE
resolving issue68, fix "Hackahton" typo in welcome page

### DIFF
--- a/src/components/UserOnboarding.Name.js
+++ b/src/components/UserOnboarding.Name.js
@@ -64,7 +64,7 @@ export class UserOnboardingName extends Component {
 
           <label className="hackathon-participant clearfix">
             <span>
-              I am interested in participating in the Make or Break hackahton
+              I am interested in participating in the Make or Break hackathon
             </span>
             <BinaryToggle
               options={[


### PR DESCRIPTION
Resolving https://github.com/makeorbreak-io/mob-web/issues/68 , "Hackahton" typo in welcome page was corrected